### PR TITLE
💰 Fix Pro subscription pricing to $19/month

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -145,7 +145,7 @@ export default function Home() {
             />
             <PricingCard
               title="Pro"
-              price="$9"
+              price="$19"
               period="month"
               features={[
                 'Unlimited operations',


### PR DESCRIPTION
Corrected the Pro plan pricing from $9 to $19/month on the homepage pricing card.

🤖 Generated with [Claude Code](https://claude.ai/code)